### PR TITLE
Adjustments of spif example to 5.10 & Adding K82F support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,9 +19,14 @@
 #include "SPIFBlockDevice.h"
 
 /* This configuration of the SPI Flash Driver pins is for
- * the the SPI pins on the Arduino header to the SPI NOR part.
+ * the SPI pins on the Arduino header to the SPI NOR part.
  */
-SPIFBlockDevice spif(D11, D12, D13, D10);
+
+SPIFBlockDevice spif(
+        MBED_CONF_SPIF_DRIVER_SPI_MOSI,
+        MBED_CONF_SPIF_DRIVER_SPI_MISO,
+        MBED_CONF_SPIF_DRIVER_SPI_CLK,
+        MBED_CONF_SPIF_DRIVER_SPI_CS);
 
 
 int main() {

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f4864dc6429e1ff5474111d4e0f6bee36a759b1c
+https://github.com/ARMmbed/mbed-os/#3fb5781af180c32a6062f050d59cdf93654b3e9f

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -78,6 +78,12 @@
              "SPI_CLK":  "PTE2",
              "SPI_CS":   "PTE4"
         },
+        "K82F": {
+             "SPI_MOSI": "PTE2",
+             "SPI_MISO": "PTE4",
+             "SPI_CLK":  "PTE1",
+             "SPI_CS":   "PTE5"
+        },
         "K66F": {
              "SPI_MOSI": "PTE3",
              "SPI_MISO": "PTE1",

--- a/spiflash-driver.lib
+++ b/spiflash-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/spiflash-driver/#2dd0c7923b29921edd41101b601feab8e8241ac8


### PR DESCRIPTION
Removing spiflash-driver.lib file, updating mbed-os.lib to mbed-os-5.10.0-rc1 tag version and adding K82F support.
@adbridge @ashok-rao 